### PR TITLE
L2 Cache Support

### DIFF
--- a/src/main/java/com/librato/disco/CachedChildData.java
+++ b/src/main/java/com/librato/disco/CachedChildData.java
@@ -1,0 +1,36 @@
+package com.librato.disco;
+
+import org.apache.curator.framework.recipes.cache.ChildData;
+
+/**
+ * Composes a child data and an expire-at ttl. This is used in a
+ * map of path -> cached child data in order to keep a relatively
+ * up to date view of the world in the event of an outage.
+ */
+class CachedChildData {
+    private ChildData data;
+    private long expireAt;
+
+    public CachedChildData(ChildData data, long expireAt) {
+        this.data = data;
+        this.expireAt = expireAt;
+    }
+
+    public synchronized ChildData getData() {
+        return data;
+    }
+
+    public synchronized  CachedChildData setData(ChildData data) {
+        this.data = data;
+        return this;
+    }
+
+    public synchronized long getExpireAt() {
+        return expireAt;
+    }
+
+    public synchronized CachedChildData setExpireAt(long expireAt) {
+        this.expireAt = expireAt;
+        return this;
+    }
+}

--- a/src/main/java/com/librato/disco/DefaultExpireStrategy.java
+++ b/src/main/java/com/librato/disco/DefaultExpireStrategy.java
@@ -1,0 +1,10 @@
+package com.librato.disco;
+
+import org.apache.curator.framework.recipes.cache.ChildData;
+
+public class DefaultExpireStrategy implements IExpireStrategy {
+    @Override
+    public boolean shouldExpire(ChildData data, long expireAtMillis) {
+        return expireAtMillis <= System.currentTimeMillis();
+    }
+}

--- a/src/main/java/com/librato/disco/DiscoClientFactory.java
+++ b/src/main/java/com/librato/disco/DiscoClientFactory.java
@@ -10,6 +10,7 @@ public class DiscoClientFactory<T> {
     private final CuratorFramework framework;
     private final SelectorStrategy strategy;
     private final Decoder<T> decoder;
+    private final ILevel2CacheStrategy l2CacheStrategy;
 
     /**
      * Constructor that defaults to using {@link RoundRobinSelectorStrategy} strategy
@@ -27,6 +28,7 @@ public class DiscoClientFactory<T> {
         this.framework = framework;
         this.strategy = strategy;
         this.decoder = null;
+        this.l2CacheStrategy = null;
     }
 
     /**
@@ -38,6 +40,20 @@ public class DiscoClientFactory<T> {
         this.framework = framework;
         this.strategy = strategy;
         this.decoder = decoder;
+        this.l2CacheStrategy = null;
+    }
+
+    /**
+     * @param framework Initialized {@link CuratorFramework}
+     * @param strategy Selector for use in this factory
+     * @param decoder Decoder for use in thie factory
+     * @param l2CacheStrategy a strategy supplier for using the l2 cache. null if no caching is desired.
+     */
+    public DiscoClientFactory(CuratorFramework framework, SelectorStrategy strategy, Decoder<T> decoder, ILevel2CacheStrategy l2CacheStrategy) {
+        this.framework = framework;
+        this.strategy = strategy;
+        this.decoder = decoder;
+        this.l2CacheStrategy = l2CacheStrategy;
     }
 
     /**
@@ -47,7 +63,13 @@ public class DiscoClientFactory<T> {
      * @return new initialized {@link DiscoClient} instance
      */
     public DiscoClient<T> buildClient(final String serviceName) {
-        final DiscoClient<T> client = new DiscoClient<>(framework, serviceName, strategy, decoder);
+        final DiscoClient<T> client;
+        client = new DiscoClient<>(
+                framework,
+                serviceName,
+                strategy,
+                decoder,
+                l2CacheStrategy);
         try {
             client.start();
         } catch (Exception e) {

--- a/src/main/java/com/librato/disco/IExpireStrategy.java
+++ b/src/main/java/com/librato/disco/IExpireStrategy.java
@@ -1,0 +1,11 @@
+package com.librato.disco;
+
+import org.apache.curator.framework.recipes.cache.ChildData;
+
+public interface IExpireStrategy {
+    /**
+     * Whether or not a certain child data should be expired
+     * based on it's expire time.
+     */
+    boolean shouldExpire(ChildData data, long expireAtMillis);
+}

--- a/src/main/java/com/librato/disco/ILevel2CacheStrategy.java
+++ b/src/main/java/com/librato/disco/ILevel2CacheStrategy.java
@@ -1,0 +1,35 @@
+package com.librato.disco;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * An implementation of this interface should be supplied to the Level2StateCache.
+ * It supplies the TTL that should be used for the l2 cache entries and also
+ * determines whether or not the l2 cache should be in a promoted state or not.
+ *
+ * Note that the strategy should probably not maintain any state, as it could
+ * be used for various services when using a DiscoClientFactory.
+ */
+public interface ILevel2CacheStrategy {
+    /**
+     * Signals to the strategy what the current l1 cache size is
+     * and also the l2 cache size.  This method should return true
+     * if the l2 cache should be in a promoted state, or false otherwise.
+     *
+     * @param serviceName the name of the service
+     * @param l1CacheSize the size of the l1 cache
+     * @param l2CacheSize the size of the l2 cache
+     * @param isPromoted  whether or not the l2 cache is already in a promoted state
+     */
+    boolean promote(String serviceName, int l1CacheSize, int l2CacheSize, boolean isPromoted);
+
+    /**
+     * How long the entries should live in the l2 cache while in a demoted state
+     */
+    long getTtl();
+
+    /**
+     * The time unit for the ttl
+     */
+    TimeUnit getTtlTimeUnit();
+}

--- a/src/main/java/com/librato/disco/IStateCache.java
+++ b/src/main/java/com/librato/disco/IStateCache.java
@@ -1,0 +1,18 @@
+package com.librato.disco;
+
+import org.apache.curator.framework.recipes.cache.ChildData;
+
+import java.util.List;
+
+/**
+ * The basic interface around being able to query for nodes. Note that
+ * implementations of this interface should not typically block for data
+ * as the methods that may call them could be synchronized.
+ */
+public interface IStateCache {
+    List<ChildData> getCurrentData();
+
+    void start() throws Exception;
+
+    void stop() throws Exception;
+}

--- a/src/main/java/com/librato/disco/Level2StateCache.java
+++ b/src/main/java/com/librato/disco/Level2StateCache.java
@@ -1,0 +1,176 @@
+package com.librato.disco;
+
+import org.apache.curator.framework.recipes.cache.ChildData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * A state cache that wraps another state cache.  In normal operation it will
+ * delegate to the other state cache and update an internal map of nodes and
+ * ttls as nodes are returned from the delegate.
+ * <p>
+ * A supplied strategy will determine whether or not the ttl cached nodes
+ * should ever be promoted. If they are promoted, during the time of promotion
+ * the ttl cached nodes will be frozen and served instead of what the delegate
+ * cache returns.  Once the strategy determines it is time to demote the l2
+ * cache, operation will return to normal, the nodes will be unfrozen, and
+ * the delegate data will be returned to the caller.
+ */
+public class Level2StateCache implements IStateCache {
+    private static final Logger log = LoggerFactory.getLogger(Level2StateCache.class);
+    private final String serviceName;
+    private final IStateCache delegate;
+    private final ILevel2CacheStrategy strat;
+    private final AtomicBoolean promoted = new AtomicBoolean();
+    private final AtomicReference<Long> promotedAt = new AtomicReference<>();
+    // path -> cached data
+    private final ConcurrentMap<String, CachedChildData> cache = new ConcurrentHashMap<>();
+    private final AtomicReference<List<ChildData>> promotedData = new AtomicReference<>();
+    private final IExpireStrategy expireStrategy;
+    private final ScheduledExecutorService monitorExecutor = Executors.newSingleThreadScheduledExecutor();
+    private volatile ScheduledFuture<?> monitorFuture;
+    private final StarterStopper starterStopper = new StarterStopper();
+
+    /**
+     * Constructor.
+     *
+     * @param delegate the cache that will populate the l2 cache
+     * @param strat    determines when to promote demote
+     */
+    public Level2StateCache(String serviceName, IStateCache delegate, ILevel2CacheStrategy strat) {
+        this(serviceName, delegate, strat, new DefaultExpireStrategy());
+    }
+
+    Level2StateCache(String serviceName, IStateCache delegate, ILevel2CacheStrategy strat, IExpireStrategy expireStrategy) {
+        this.serviceName = serviceName;
+        this.delegate = delegate;
+        this.strat = strat;
+        this.expireStrategy = expireStrategy;
+    }
+
+    @Override
+    public List<ChildData> getCurrentData() {
+        List<ChildData> data = delegate.getCurrentData();
+        if (strat == null) {
+            // cache is disbled if strat is null
+            return data;
+        }
+
+        updateCache(data);
+        prune();
+
+        // signal to the strat that we have delegate data
+        boolean shouldPromote = strat.promote(serviceName, data.size(), cache.size(), promoted.get());
+
+        List<ChildData> promotedData = getPromotedData(shouldPromote);
+        if (promotedData != null && !promotedData.isEmpty()) {
+            return promotedData;
+        }
+
+        // by default return the delegate data
+        return data;
+    }
+
+    /**
+     * A synchronized method which sets the l2 state to a promoted or demoted
+     * state based on what the strategy dictated.
+     * <p>
+     * If the strategy recommends promotion then it will attempt to set the
+     * state of the cache to promoted and will set a reference to the
+     * data frozen at the time of promotion. If the strategy recommends promotion
+     * it will return the current frozen data.
+     * <p>
+     * If the strategy does not recommend promotion then it will return null
+     * to signify that it should use the upstream delegate cached data.
+     *
+     * @param shouldPromote whether or not the strat recommended promotion
+     */
+    private synchronized List<ChildData> getPromotedData(boolean shouldPromote) {
+        if (shouldPromote) {
+            if (this.promoted.compareAndSet(false, true)) {
+                List<ChildData> newPromotion = new ArrayList<>();
+                for (CachedChildData data : cache.values()) {
+                    newPromotion.add(data.getData());
+                }
+                Collections.sort(newPromotion);
+                log.error("Promoting L2 cache for {} using {} promoted child data nodes", serviceName, newPromotion.size());
+                promotedData.set(newPromotion);
+                promotedAt.set(System.currentTimeMillis());
+            }
+            return promotedData.get();
+        } else {
+            if (this.promoted.compareAndSet(true, false)) {
+                log.info("Demoting L2 cache for {}", serviceName);
+                promotedData.set(null);
+                promotedAt.set(null);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Updates the cache with the specified data.
+     */
+    private void updateCache(List<ChildData> data) {
+        for (ChildData childData : data) {
+            long stratTtl = strat.getTtlTimeUnit().toMillis(strat.getTtl());
+            long expireAtMillis = System.currentTimeMillis() + stratTtl;
+            CachedChildData cachedData = cache.get(childData.getPath());
+            if (cachedData == null) {
+                cachedData = new CachedChildData(childData, expireAtMillis);
+                cache.put(childData.getPath(), cachedData);
+            } else {
+                cachedData.setData(childData);
+                cachedData.setExpireAt(expireAtMillis);
+            }
+        }
+    }
+
+    /**
+     * Removes any entries from the cache which are too old
+     */
+    private void prune() {
+        Iterator<Map.Entry<String, CachedChildData>> iterator = cache.entrySet().iterator();
+        while (iterator.hasNext()) {
+            Map.Entry<String, CachedChildData> entry = iterator.next();
+            CachedChildData cached = entry.getValue();
+            if (expireStrategy.shouldExpire(cached.getData(), cached.getExpireAt())) {
+                log.info("Expiring {} due to TTL", cached.getData().getPath());
+                iterator.remove();
+            }
+        }
+    }
+
+    @Override
+    public void start() throws Exception {
+        starterStopper.start();
+        delegate.start();
+        monitorFuture = monitorExecutor.scheduleWithFixedDelay(new Runnable() {
+            @Override
+            public void run() {
+                Long promotedAtMillis = promotedAt.get();
+                if (promotedAtMillis != null) {
+                    long promotionDurationMillis = System.currentTimeMillis() - promotedAtMillis;
+                    // if longer than a minute of promotion
+                    if (promotionDurationMillis > 1000 * 60) {
+                        log.error("L2 cache for {} has been promoted for {}s", serviceName, promotionDurationMillis / 1000);
+                    }
+                }
+            }
+        }, 1, 1, TimeUnit.MINUTES);
+    }
+
+    @Override
+    public void stop() throws Exception {
+        starterStopper.stop();
+        delegate.stop();
+        if (monitorFuture != null) {
+            monitorFuture.cancel(false);
+        }
+    }
+}

--- a/src/main/java/com/librato/disco/PathChildrenStateCache.java
+++ b/src/main/java/com/librato/disco/PathChildrenStateCache.java
@@ -1,0 +1,73 @@
+package com.librato.disco;
+
+import com.google.common.base.Preconditions;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.imps.CuratorFrameworkState;
+import org.apache.curator.framework.recipes.cache.ChildData;
+import org.apache.curator.framework.recipes.cache.PathChildrenCache;
+import org.apache.curator.framework.recipes.cache.PathChildrenCacheEvent;
+import org.apache.curator.framework.recipes.cache.PathChildrenCacheListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+
+public class PathChildrenStateCache implements IStateCache {
+    private static final Logger log = LoggerFactory.getLogger(PathChildrenStateCache.class);
+    private final PathChildrenCache cache;
+    private final CuratorFramework framework;
+    private final String serviceName;
+    private final String serviceNode;
+    private final StarterStopper starterStopper = new StarterStopper();
+
+    public PathChildrenStateCache(CuratorFramework framework, String serviceName, String serviceNode) {
+        this.framework = framework;
+        this.serviceName = serviceName;
+        this.serviceNode = serviceNode;
+        cache = new PathChildrenCache(framework, serviceNode, true);
+    }
+
+    @Override
+    public List<ChildData> getCurrentData() {
+        return cache.getCurrentData();
+    }
+
+    @Override
+    public void start() throws Exception {
+        starterStopper.start();
+        Preconditions.checkArgument(framework.getState() == CuratorFrameworkState.STARTED);
+        if (framework.checkExists().forPath(serviceNode) == null) {
+            framework.create().creatingParentsIfNeeded().forPath(serviceNode);
+        }
+        cache.getListenable().addListener(new PathChildrenCacheListener() {
+            public void childEvent(CuratorFramework client, PathChildrenCacheEvent event) throws Exception {
+                switch (event.getType()) {
+                    case CHILD_ADDED:
+                        log.info("`{}` service node added: {}", serviceName, event.getData().getPath());
+                        break;
+                    case CHILD_UPDATED:
+                        break;
+                    case CHILD_REMOVED:
+                        log.info("`{}` service node removed: {}", serviceName, event.getData().getPath());
+                        break;
+                    case CONNECTION_SUSPENDED:
+                        break;
+                    case CONNECTION_RECONNECTED:
+                        break;
+                    case CONNECTION_LOST:
+                        break;
+                    case INITIALIZED:
+                        break;
+                }
+            }
+        });
+        cache.start(PathChildrenCache.StartMode.BUILD_INITIAL_CACHE);
+    }
+
+    @Override
+    public void stop() throws Exception {
+        starterStopper.stop();
+        cache.close();
+    }
+}

--- a/src/main/java/com/librato/disco/PercentageThresholdLevel2CacheStrategy.java
+++ b/src/main/java/com/librato/disco/PercentageThresholdLevel2CacheStrategy.java
@@ -1,0 +1,68 @@
+package com.librato.disco;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A level 2 cache strategy that promotes based on the percentage of l1 nodes
+ * versus l2 nodes dropping below a threshold.
+ */
+public class PercentageThresholdLevel2CacheStrategy implements ILevel2CacheStrategy {
+    private static final Logger log = LoggerFactory.getLogger(PercentageThresholdLevel2CacheStrategy.class);
+    private final ThrottledRunner printPercentageRunner = new ThrottledRunner(5, TimeUnit.SECONDS);
+    private final double threshold;
+    private final long ttl;
+    private final TimeUnit ttlUnit;
+
+    public PercentageThresholdLevel2CacheStrategy(double threshold,
+                                                  long l2CacheTtl,
+                                                  TimeUnit l2CacheTtlUnit) {
+        this.threshold = threshold;
+        this.ttl = l2CacheTtl;
+        this.ttlUnit = l2CacheTtlUnit;
+    }
+
+    @Override
+    public boolean promote(final String serviceName, int l1CacheSize, int l2CacheSize, boolean isPromoted) {
+        if (l1CacheSize == l2CacheSize && l1CacheSize > 0 && l2CacheSize > 0) {
+            // we're fine.
+            return false;
+        }
+        if (l2CacheSize == 0) {
+            // all of the l2 cache entries have ttl'd out. keep the promoted state.
+            return isPromoted;
+        }
+        // here we are guaranteed to not have a divide by zero error
+        final double percentageOfL2CacheSize = (double) l1CacheSize / (double) l2CacheSize;
+        printPercentageRunner.run(new Runnable() {
+            @Override
+            public void run() {
+                printPercentage(serviceName, percentageOfL2CacheSize);
+            }
+        });
+        if (l2CacheSize <= 2) {
+            // special case. only promote when l1 cache size is zero
+            return l1CacheSize == 0;
+        }
+        return percentageOfL2CacheSize <= threshold;
+    }
+
+    private synchronized void printPercentage(String serviceName, double percentage) {
+        String formattedPercentage = String.format("%.2f", percentage);
+        if (percentage < 1.0) {
+            log.warn("Current percentage for {} is {} [threshold is {}]", serviceName, formattedPercentage, threshold);
+        }
+    }
+
+    @Override
+    public long getTtl() {
+        return ttl;
+    }
+
+    @Override
+    public TimeUnit getTtlTimeUnit() {
+        return ttlUnit;
+    }
+}

--- a/src/main/java/com/librato/disco/StarterStopper.java
+++ b/src/main/java/com/librato/disco/StarterStopper.java
@@ -1,0 +1,21 @@
+package com.librato.disco;
+
+import com.google.common.base.Preconditions;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class StarterStopper {
+    private final AtomicBoolean started = new AtomicBoolean();
+
+    public void start() {
+        Preconditions.checkArgument(started.compareAndSet(false, true));
+    }
+
+    public void stop() {
+        Preconditions.checkArgument(started.compareAndSet(true, false));
+    }
+
+    public boolean isStarted() {
+        return started.get();
+    }
+}

--- a/src/main/java/com/librato/disco/Supplier.java
+++ b/src/main/java/com/librato/disco/Supplier.java
@@ -1,0 +1,5 @@
+package com.librato.disco;
+
+public interface Supplier<T> {
+    T get();
+}

--- a/src/main/java/com/librato/disco/ThrottledRunner.java
+++ b/src/main/java/com/librato/disco/ThrottledRunner.java
@@ -1,0 +1,22 @@
+package com.librato.disco;
+
+import java.util.concurrent.TimeUnit;
+
+public class ThrottledRunner {
+    private final long runOnlyEvery;
+    private final TimeUnit runOnlyEveryUnit;
+    private long lastRunAt;
+
+    public ThrottledRunner(long runOnlyEvery, TimeUnit runOnlyEveryUnit) {
+        this.runOnlyEvery = runOnlyEvery;
+        this.runOnlyEveryUnit = runOnlyEveryUnit;
+    }
+
+    public synchronized void run(Runnable delegate) {
+        long now = System.currentTimeMillis();
+        if (now - runOnlyEveryUnit.toMillis(runOnlyEvery) >= lastRunAt) {
+            delegate.run();
+            lastRunAt = now;
+        }
+    }
+}

--- a/src/main/java/com/librato/disco/ThrottledSupplier.java
+++ b/src/main/java/com/librato/disco/ThrottledSupplier.java
@@ -1,0 +1,30 @@
+package com.librato.disco;
+
+import java.util.concurrent.TimeUnit;
+
+public class ThrottledSupplier<T> {
+    interface Supplier<T> {
+        T get();
+    }
+
+    final long callEvery;
+    final TimeUnit callEveryUnit;
+    final Supplier<T> delegate;
+    long lastGetAt;
+    T lastValue;
+
+    public ThrottledSupplier(long callEvery, TimeUnit callEveryUnit, Supplier<T> delegate) {
+        this.callEvery = callEvery;
+        this.callEveryUnit = callEveryUnit;
+        this.delegate = delegate;
+    }
+
+    public synchronized T get() {
+        long now = System.currentTimeMillis();
+        if (now - callEveryUnit.toMillis(callEvery) >= lastGetAt) {
+            lastValue = delegate.get();
+            lastGetAt = now;
+        }
+        return lastValue;
+    }
+}

--- a/src/test/java/com/librato/disco/AbstractStateCache.java
+++ b/src/test/java/com/librato/disco/AbstractStateCache.java
@@ -1,0 +1,13 @@
+package com.librato.disco;
+
+public abstract class AbstractStateCache implements IStateCache {
+    @Override
+    public void start() throws Exception {
+
+    }
+
+    @Override
+    public void stop() throws Exception {
+
+    }
+}

--- a/src/test/java/com/librato/disco/DiscoClientTest.java
+++ b/src/test/java/com/librato/disco/DiscoClientTest.java
@@ -14,15 +14,10 @@ import org.mockito.stubbing.Answer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.util.HashSet;
 import java.util.Objects;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
@@ -179,7 +174,7 @@ public class DiscoClientTest {
         if (client != null) {
             try {
                 client.stop();
-            } catch (IOException ex) {
+            } catch (Exception ex) {
                 log.error("stopping DiscoService failed", ex);
             }
         }

--- a/src/test/java/com/librato/disco/FakeChildData.java
+++ b/src/test/java/com/librato/disco/FakeChildData.java
@@ -1,0 +1,14 @@
+package com.librato.disco;
+
+import org.apache.curator.framework.recipes.cache.ChildData;
+
+public class FakeChildData extends ChildData {
+
+    public static ChildData newData(String data) {
+        return new FakeChildData(data);
+    }
+
+    public FakeChildData(String data) {
+        super("/path/data-" + data, null, data.getBytes());
+    }
+}

--- a/src/test/java/com/librato/disco/FakeLevel2CacheStrategy.java
+++ b/src/test/java/com/librato/disco/FakeLevel2CacheStrategy.java
@@ -1,0 +1,38 @@
+package com.librato.disco;
+
+import java.util.concurrent.TimeUnit;
+
+class FakeLevel2CacheStrategy implements ILevel2CacheStrategy {
+    long ttl;
+    TimeUnit ttlUnit;
+    boolean promote;
+
+    public FakeLevel2CacheStrategy(long ttl, TimeUnit ttlUnit) {
+        this.ttl = ttl;
+        this.ttlUnit = ttlUnit;
+    }
+
+    @Override
+    public boolean promote(String serviceName, int l1CacheSize, int l2CacheSize, boolean isPromoted) {
+        return promote;
+    }
+
+    @Override
+    public long getTtl() {
+        return ttl;
+    }
+
+    @Override
+    public TimeUnit getTtlTimeUnit() {
+        return ttlUnit;
+    }
+
+    public void setPromote(boolean promote) {
+        this.promote = promote;
+    }
+
+    public void setTtl(long ttl, TimeUnit unit) {
+        this.ttl = ttl;
+        this.ttlUnit = unit;
+    }
+}

--- a/src/test/java/com/librato/disco/FakeStateCache.java
+++ b/src/test/java/com/librato/disco/FakeStateCache.java
@@ -1,0 +1,31 @@
+package com.librato.disco;
+
+import org.apache.curator.framework.recipes.cache.ChildData;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+class FakeStateCache extends AbstractStateCache {
+    List<ChildData> currentData = new CopyOnWriteArrayList<>();
+
+    @Override
+    public List<ChildData> getCurrentData() {
+        return currentData;
+    }
+
+    public void add(ChildData... data) {
+        for (ChildData childData : data) {
+            if (!this.currentData.contains(childData)) {
+                this.currentData.add(childData);
+            }
+        }
+    }
+
+    public void remove(ChildData data) {
+        this.currentData.remove(data);
+    }
+
+    public void clear() {
+        this.currentData.clear();
+    }
+}

--- a/src/test/java/com/librato/disco/Level2StateCacheTest.java
+++ b/src/test/java/com/librato/disco/Level2StateCacheTest.java
@@ -1,0 +1,117 @@
+package com.librato.disco;
+
+import org.apache.curator.framework.recipes.cache.ChildData;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static com.librato.disco.FakeChildData.newData;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class Level2StateCacheTest {
+    static final List<ChildData> noData = Collections.emptyList();
+    String serviceName = "foo";
+
+    @Test
+    public void testDelegatesToL1Cache() throws Exception {
+        FakeStateCache l1Cache = new FakeStateCache();
+        FakeLevel2CacheStrategy strategy = new FakeLevel2CacheStrategy(10, SECONDS);
+        Level2StateCache l2Cache = new Level2StateCache(serviceName, l1Cache, strategy);
+        assertThat(l2Cache.getCurrentData(), equalTo(noData));
+
+        ChildData c1 = newData("c1");
+
+        l1Cache.add(c1);
+        assertThat(l2Cache.getCurrentData(), equalTo(singletonList(c1)));
+
+        l1Cache.remove(c1);
+        assertThat(l2Cache.getCurrentData(), equalTo(noData));
+    }
+
+    @Test
+    public void testPromotes() throws Exception {
+        FakeStateCache l1Cache = new FakeStateCache();
+        FakeLevel2CacheStrategy strategy = new FakeLevel2CacheStrategy(10, SECONDS);
+        Level2StateCache l2Cache = new Level2StateCache(serviceName, l1Cache, strategy);
+        assertThat(l2Cache.getCurrentData(), equalTo(noData));
+
+        ChildData c1 = newData("c1");
+        ChildData c2 = newData("c2");
+
+        l1Cache.add(c1, c2);
+        assertThat(l2Cache.getCurrentData(), equalTo(asList(c1, c2)));
+
+        // verify that during promotion no changes to the l1 cache propagate
+        strategy.setPromote(true);
+        l1Cache.clear();
+        assertThat(l1Cache.getCurrentData(), equalTo(noData));
+        assertThat(l2Cache.getCurrentData(), equalTo(asList(c1, c2)));
+
+        ChildData c3 = newData("c3");
+        ChildData c4 = newData("c4");
+        l1Cache.add(c2, c3, c4);
+        assertThat(l1Cache.getCurrentData(), equalTo(asList(c2, c3, c4)));
+        assertThat(l2Cache.getCurrentData(), equalTo(asList(c1, c2)));
+
+        strategy.setPromote(false);
+        assertThat(l1Cache.getCurrentData(), equalTo(asList(c2, c3, c4)));
+        assertThat(l2Cache.getCurrentData(), equalTo(asList(c2, c3, c4)));
+
+        l1Cache.remove(c4);
+        assertThat(l1Cache.getCurrentData(), equalTo(asList(c2, c3)));
+        assertThat(l2Cache.getCurrentData(), equalTo(asList(c2, c3)));
+    }
+
+    @Test
+    public void expiresEntries() throws Exception {
+        FakeStateCache l1Cache = new FakeStateCache();
+        FakeLevel2CacheStrategy strategy = new FakeLevel2CacheStrategy(10, SECONDS);
+        IExpireStrategy expireStrategy = mock(IExpireStrategy.class);
+        Level2StateCache l2Cache = new Level2StateCache(serviceName, l1Cache, strategy, expireStrategy);
+        assertThat(l2Cache.getCurrentData(), equalTo(noData));
+
+        ChildData c1 = newData("c1");
+        ChildData c2 = newData("c2");
+        ChildData c3 = newData("c3");
+        l1Cache.add(c1, c2, c3);
+        assertThat(l2Cache.getCurrentData(), equalTo(asList(c1, c2, c3)));
+
+        // remove c2 from the l1 cache, but at this point c2 should not yet be expired in the l2 cache
+        l1Cache.remove(c2);
+        strategy.setPromote(true);
+        // therefore it should be in the returned results
+        assertThat(l2Cache.getCurrentData(), equalTo(asList(c1, c2, c3)));
+
+        // demote the l2 cache, and now we should have c1 and c3 returned
+        strategy.setPromote(false);
+        assertThat(l2Cache.getCurrentData(), equalTo(asList(c1, c3)));
+
+        // if we promote again we should get all three returned
+        strategy.setPromote(true);
+        assertThat(l2Cache.getCurrentData(), equalTo(asList(c1, c2, c3)));
+
+        // if we expire c2 from the l2 cache it should still be returned as it
+        // is in the promoted state
+        when(expireStrategy.shouldExpire(eq(c2), anyLong())).thenReturn(true);
+        assertThat(l2Cache.getCurrentData(), equalTo(asList(c1, c2, c3)));
+
+        // because it is expired, and also not in the l1 cache, when we demote
+        // the l2 cache it should be pruned
+        strategy.setPromote(false);
+        assertThat(l2Cache.getCurrentData(), equalTo(asList(c1, c3)));
+        // and then once we promote again, because it has been expired, it won't
+        // be in the frozen list
+        strategy.setPromote(true);
+        assertThat(l2Cache.getCurrentData(), equalTo(asList(c1, c3)));
+    }
+
+}

--- a/src/test/java/com/librato/disco/PercentageThresholdLevel2CacheStrategyTest.java
+++ b/src/test/java/com/librato/disco/PercentageThresholdLevel2CacheStrategyTest.java
@@ -1,0 +1,42 @@
+package com.librato.disco;
+
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class PercentageThresholdLevel2CacheStrategyTest {
+    String serviceName = "foo";
+
+    @Test
+    public void basicOperation() throws Exception {
+        double threshold = 0.5;
+        PercentageThresholdLevel2CacheStrategy strategy = new PercentageThresholdLevel2CacheStrategy(
+                threshold,
+                5, TimeUnit.MINUTES);
+
+        // l1 size of 4 and l2 size of 4
+        assertThat(strategy.promote(serviceName, 4, 4, false), equalTo(false));
+
+        // remove one of the delegate datas, keep the l2 cache size of 4
+        assertThat(strategy.promote(serviceName, 3, 4, false), equalTo(false));
+
+        // remove one more, that should be 50%
+        assertThat(strategy.promote(serviceName, 2, 4, false), equalTo(true));
+
+        // verify that the strategy still thinks it should be promoted
+        assertThat(strategy.promote(serviceName, 2, 4, false), equalTo(true));
+
+        // edge case, still remove yet another one
+        assertThat(strategy.promote(serviceName, 1, 4, true), equalTo(true));
+
+        // restore to > 50 % verify it should not promote now
+        assertThat(strategy.promote(serviceName, 3, 4, true), equalTo(false));
+
+        // if both are zero, edge case, keep existing promotion status
+        assertThat(strategy.promote(serviceName, 0, 0, true), equalTo(true));
+        assertThat(strategy.promote(serviceName, 0, 0, false), equalTo(false));
+    }
+}

--- a/src/test/java/com/librato/disco/ThrottledSupplierTest.java
+++ b/src/test/java/com/librato/disco/ThrottledSupplierTest.java
@@ -1,0 +1,31 @@
+package com.librato.disco;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+public class ThrottledSupplierTest {
+    class FakeDoubleSupplier implements ThrottledSupplier.Supplier<Double> {
+        volatile double value = 0;
+
+        @Override
+        public Double get() {
+            return value;
+        }
+    }
+
+    @Test
+    public void basicOperation() throws Exception {
+        FakeDoubleSupplier delegate = new FakeDoubleSupplier();
+        ThrottledSupplier<Double> supplier = new ThrottledSupplier<>(200, TimeUnit.MILLISECONDS, delegate);
+        Assert.assertThat(supplier.get(), CoreMatchers.equalTo(0D));
+
+        delegate.value = 1;
+        Assert.assertThat(supplier.get(), CoreMatchers.equalTo(0D));
+
+        Thread.sleep(200);
+        Assert.assertThat(supplier.get(), CoreMatchers.equalTo(1D));
+    }
+}


### PR DESCRIPTION
This changeset adds a second layer of caching to the disco client.  Originally this library already used a curator `PathChildrenCache` in the client. 

This has been generalized into an `IStateCache` type, and the `PathChildrenCache` code has been adapted to it.  The client now uses a generic `IStateCache` instead of the `PathChildrenCache` in order to query for the current state.

In addition, an implementation of `IStateCache` has been created to implement L2 caching; this is the `Level2StateCache` type.  The client will query this L2 cache, which also has a reference to a delegate `IStateCache` for its data, and also composes a strategy type which will drive its behavior.

Testing needs to be implemented but I wanted to get some feedback on the overall design before going further.